### PR TITLE
Hard-code required parser gem version to 2.2.0.pre.5

### DIFF
--- a/zombie-killer.gemspec
+++ b/zombie-killer.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   # dependencies
   spec.add_dependency "docopt"
-  spec.add_dependency "parser"
+  spec.add_dependency "parser", "2.2.0.pre.5"
   spec.add_dependency "unparser"
 
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
We're using Source::Rewriter#transaction, which is only implemented in
2.2.0 pre-release versions. Because pre-release version aren't installed
by default, we need to set the version explicitly in .gemspec.
