### PR TITLE
Change on_vasgn to more precise on_lvasgn

### DIFF
--- a/lib/zombie_killer/rewriter.rb
+++ b/lib/zombie_killer/rewriter.rb
@@ -174,8 +174,7 @@ class ZombieKillerRewriter < Parser::Rewriter
     scope.clear
   end
 
-  # local(?) variable assignment
-  def on_vasgn(node)
+  def on_lvasgn(node)
     super
     name, value = * node
     return if value.nil? # and-asgn, or-asgn, resbody do this


### PR DESCRIPTION
This change means that only local variables are put into the current
scope (not global, instance, and class ones). This is how it should be.

Note the change doesn't change visible behavior because:
1. All variable types previously stored in the scope had unique
    prefixes ("@", "@@", or "$"), which means they didn't conflict with
    local variables also stored there. The scope just contained
    additional incorrect information.
2. We check for variable type in "nice_variable", meaning the
    additional incorrect information stored in the scope didn't affect
    anything.
