### PR TITLE
Handle "masgn" and "mlhs" nodes

### DIFF
--- a/lib/zombie_killer/rewriter.rb
+++ b/lib/zombie_killer/rewriter.rb
@@ -83,6 +83,8 @@ class ZombieKillerRewriter < Parser::Rewriter
     :kwoptarg,                  # Keyword optional argument, def m(a: 1)
     :lvar,                      # Local variable value
     :lvasgn,                    # Local variable assignment
+    :masgn,                     # Multiple assigment: a, b = c, d
+    :mlhs,                      # Left-hand side of a multiple assigment: a, b = c, d
     :module,                    # Module body
     :nil,                       # nil literal
     :nth_ref,                   # Regexp back references: $1, $2...

--- a/spec/zombie_killer_spec.md
+++ b/spec/zombie_killer_spec.md
@@ -127,6 +127,18 @@ v = "Hello"
 v + "World"
 ```
 
+Zombie Killer doesn't translate `Ops.add(nice_variable, literal)` when the
+variable got it's niceness via multiple assignemnt. We chose to ignore multiple
+assigments for now because of their complicated semantics (especially in
+presence of splats).
+
+**Unchanged**
+
+```ruby
+v1, v2 = "Hello", "World"
+Ops.add(v1, v2)
+```
+
 Zombie Killer translates `Ops.add(nontrivially_nice_variable, literal)`.
 
 **Original**


### PR DESCRIPTION
We chose to ignore multiple assigments for now because of their
complicated semantics (especially in presence of splats).
