### PR TITLE
Added zk -e, EagerRewriter (don't care about niceness, replace all)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 spec/zombie_killer_spec.html
 spec/zombie_killer_spec.rb
 /vendor/
+/zombie-killer-*.gem

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+/.bundle/
+/coverage/
 Gemfile.lock
 spec/zombie_killer_spec.html
 spec/zombie_killer_spec.rb
+/vendor/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,14 @@
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
+Metrics/ClassLength:
+  Max: 250
+
+Metrics/LineLength:
+  Max: 99
+
+#inherit_from: .rubocop_todo.yml
+

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,18 @@
+# News
+
+## unreleased
+
+## 0.4, 2018-11-02
+
+- Added zk -e, EagerRewriter (don't care about niceness, replace all)
+- Recover from parse errors by reverting to the original file
+- Fixed reporting unhandled node types
+- Handle keyword arguments, regex match
+
+## 0.3, 2014-12-02
+
+- bin/count_method_calls added
+
+## 0.2, 2014-11-28
+
+- first release as a gem

--- a/bin/zk
+++ b/bin/zk
@@ -12,6 +12,7 @@ Usage: zk [options] [FILES...]
 Arguments:
   FILES  Files to operate on, patterns allowed [default: **/*.rb]
 Options:
+  -e, --eager                Translate all zombies regardless of niceness.
   -u, --unsafe               Translate even constructs not known to be safe.
   -s, --stats                Also print statistics about node types.
   -v, --version              Print version information and exit.
@@ -21,7 +22,7 @@ EOT
 begin
   options = Docopt.docopt(doc, help: true, version: ZombieKiller::VERSION)
 
-  killer = ZombieKiller.new
+  killer = ZombieKiller.new(eager: options["--eager"])
 
   files = options["FILES"]
   files << "**/*.rb" if files.empty?

--- a/lib/zombie_killer/eager_rewriter.rb
+++ b/lib/zombie_killer/eager_rewriter.rb
@@ -1,0 +1,56 @@
+require "unparser"
+require "set"
+
+# Rewrite Zombies with their idiomatic replacements
+class EagerRewriter < Parser::TreeRewriter
+  OPS = Parser::AST::Node.new(:const, [nil, :Ops])
+
+  INFIX = {
+    add: :+,
+    subtract: :-,
+    multiply: :*,
+    divide: :/,
+    modulo: :%,
+    bitwise_and: :&,
+    bitwise_or: :|,
+    bitwise_xor: :^,
+
+    less_than: :<,
+    less_or_equal: :<=,
+    greater_than: :>,
+    greater_or_equal: :>=
+  }.freeze
+
+  def s(name, *children)
+    Parser::AST::Node.new(name, children)
+  end
+
+  def replace_node(old_node, new_node)
+    source_range = old_node.loc.expression
+    replace(source_range, Unparser.unparse(new_node))
+  end
+
+  def on_send(node)
+    super
+    receiver, name, *args = *node
+    replacement = INFIX[name]
+    if receiver == OPS && replacement && args.size == 2
+      replace_node(node, s(:send, args[0], replacement, args[1]))
+    end
+  end
+
+  AS_OPS = Set.new [:+, :-]
+  def on_lvasgn(node)
+    super
+    vname1, value = *node
+    return unless value && value.type == :send
+    receiver, oname, *args = *value
+    if vname1 == lvar_vname2(receiver) && AS_OPS.include?(oname)
+      replace_node(node, s(:op_asgn, s(:lvasgn, vname1), oname, args[0]))
+    end
+  end
+
+  def lvar_vname2(receiver)
+    receiver.children.first if receiver && receiver.type == :lvar
+  end
+end

--- a/lib/zombie_killer/killer.rb
+++ b/lib/zombie_killer/killer.rb
@@ -22,7 +22,13 @@ class ZombieKiller
       rewriter = eager ? EagerRewriter.new : ZombieKillerRewriter.new(unsafe: unsafe)
       buffer   = Parser::Source::Buffer.new(filename)
       buffer.source = c
-      rewriter.rewrite(buffer, parser.parse(buffer))
+      ast = parser.parse(buffer)
+      if ast
+        rewriter.rewrite(buffer, ast)
+      else
+        puts "Parse error for '#{filename}', returning it unchanged"
+        return code
+      end
     end
   end
   alias_method :kill, :kill_string
@@ -32,6 +38,9 @@ class ZombieKiller
     new_string = kill_string(File.read(filename), filename, unsafe: unsafe)
 
     File.write(new_filename, new_string)
+  rescue
+    puts "While processing #{filename}"
+    raise
   end
 
   private

--- a/lib/zombie_killer/killer.rb
+++ b/lib/zombie_killer/killer.rb
@@ -1,14 +1,25 @@
 require "parser"
 require "parser/current"
 
+require_relative "eager_rewriter"
 require_relative "rewriter"
 
+# The main class called from the CLI
 class ZombieKiller
+  # @return [Boolean] use the EagerRewriter
+  attr_reader :eager
+
+  def initialize(eager: false)
+    @eager = eager
+  end
+
+  # @param code [String]
+  # @param filename [String]
   # @returns new string
   def kill_string(code, filename = "(inline code)", unsafe: false)
     fixed_point(code) do |c|
       parser   = Parser::CurrentRuby.new
-      rewriter = ZombieKillerRewriter.new(unsafe: unsafe)
+      rewriter = eager ? EagerRewriter.new : ZombieKillerRewriter.new(unsafe: unsafe)
       buffer   = Parser::Source::Buffer.new(filename)
       buffer.source = c
       rewriter.rewrite(buffer, parser.parse(buffer))

--- a/lib/zombie_killer/rewriter.rb
+++ b/lib/zombie_killer/rewriter.rb
@@ -63,10 +63,14 @@ class ZombieKillerRewriter < Parser::Rewriter
     :if,                        # If and Unless
     :ivar,                      # Instance variable value
     :ivasgn,                    # Instance variable assignment
+    :kwarg,                     # Keyword argument, def m(a:)
     :kwbegin,                   # A variant of begin; for rescue and while_post
     :kwoptarg,                  # Keyword optional argument, def m(a: 1)
+    :kwrestarg,                 # Rest of keyword arguments, def m(**kwargs)
+    :kwsplat,                   # Hash **splatting
     :lvar,                      # Local variable value
     :lvasgn,                    # Local variable assignment
+    :match_with_lvasgn,         # /regex/ =~ value
     :masgn,                     # Multiple assigment: a, b = c, d
     :mlhs,                      # Left-hand side of a multiple assigment: a, b = c, d
     :module,                    # Module body

--- a/lib/zombie_killer/version.rb
+++ b/lib/zombie_killer/version.rb
@@ -1,3 +1,3 @@
 class ZombieKiller
-  VERSION = "0.3"
+  VERSION = "0.4".freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,25 @@
-$:.unshift File.expand_path("../../lib", __FILE__)
+if ENV["COVERAGE"]
+  require "simplecov"
+  SimpleCov.start
+
+  top_location = File.expand_path("../../", __FILE__)
+  # track all ruby files under lib
+  SimpleCov.track_files("#{top_location}/lib/**/*.rb")
+
+  # use coveralls for on-line code coverage reporting at Travis CI
+  if ENV["TRAVIS"]
+    require "coveralls"
+    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new [
+      SimpleCov::Formatter::HTMLFormatter,
+      Coveralls::SimpleCov::Formatter
+    ]
+  end
+end
+
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "zombie_killer"
 
 def cleanup(s)
   s.split("\n").reject { |l| l =~ /^\s*$/ }.first =~ /^(\s*)/
-  s.gsub(Regexp.new("^#{$1}"), "")[0..-2]
+  s.gsub(Regexp.new("^#{Regexp.last_match(1)}"), "")[0..-2]
 end

--- a/zombie-killer.gemspec
+++ b/zombie-killer.gemspec
@@ -34,6 +34,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "parser",   "> 2.2.0.pre.5", "< 3"
   spec.add_dependency "unparser", "~> 0"
 
+  spec.add_development_dependency "coveralls"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec",     "> 2", "< 4"
   spec.add_development_dependency "redcarpet", "~> 3"
+  spec.add_development_dependency "simplecov"
 end

--- a/zombie-killer.gemspec
+++ b/zombie-killer.gemspec
@@ -12,11 +12,12 @@ Gem::Specification.new do |spec|
   spec.license  = "MIT"
   spec.authors  = ["Martin Vidner", "David Majda"]
   spec.email    = ["martin@vidner.net", "david@majda.cz"]
-  spec.homepage = "http://github.org/yast/zombie-killer"
+  spec.homepage = "https://github.com/yast/zombie-killer"
 
   # gem content
   spec.files    = Dir[
     "LICENSE",
+    "NEWS.md",
     "README.md",
     "bin/count_method_calls",
     "bin/zk",
@@ -31,12 +32,12 @@ Gem::Specification.new do |spec|
 
   # dependencies
   spec.add_dependency "docopt",   "~> 0"
-  spec.add_dependency "parser",   "> 2.2.0.pre.5", "< 3"
+  spec.add_dependency "parser",   ">= 2.2.0", "< 3"
   spec.add_dependency "unparser", "~> 0"
 
-  spec.add_development_dependency "coveralls"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "coveralls", "~> 0"
+  spec.add_development_dependency "rake", ">=10", "< 999"
   spec.add_development_dependency "rspec",     "> 2", "< 4"
   spec.add_development_dependency "redcarpet", "~> 3"
-  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency "simplecov", "~> 0"
 end


### PR DESCRIPTION
Previously, my efforts on Zombie Killer stalled because I wanted it to be perfect, killing precisely those zombies that were safe to kill. Now I added an **eager mode** where it kills as many zombies as it can, assuming that it will make some mistakes, that you want to see the original intent before refactoring the code an and that you have covered the code with tests.

Here's an example of eagerly rewriting [inst_kickoff.rb](https://github.com/yast/yast-packager/blob/master/src/clients/inst_kickoff.rb):
https://gist.github.com/mvidner/0f4844437169e6669d2b72ece0c0485a
 inst_kickoff.rb |  203 +++++++++++---------------------------------------------
 1 file changed, 40 insertions(+), 163 deletions(-)
